### PR TITLE
ci(docker): add devcontainer base Dockerfile and publish workflow

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -1,0 +1,34 @@
+name: Build and publish devcontainer base image
+
+on:
+  push:
+    paths:
+      - 'docker/**'
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./docker
+          file: ./docker/devcontainer-base.Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/odoo-devcontainer-base:latest

--- a/docker/devcontainer-base.Dockerfile
+++ b/docker/devcontainer-base.Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-focal
+
+LABEL org.opencontainers.image.title="odoo-devcontainer-base"
+LABEL org.opencontainers.image.description="Base image for Odoo development with build deps for python-ldap and common native libs preinstalled."
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Instalar dependencias del sistema necesarias para compilar extensiones nativas
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libldap2-dev \
+        libsasl2-dev \
+        libssl-dev \
+        pkg-config \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Crear un usuario no-root (mantener compatibilidad con devcontainers)
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd -s /bin/bash --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} || true
+
+USER ${USERNAME}
+WORKDIR /workspaces/odoo


### PR DESCRIPTION
Add a Dockerfile that preinstalls native build deps required by the devcontainer (libldap2-dev, libsasl2-dev, libssl-dev, build-essential), and a GH Actions workflow to build and publish the image to GHCR.