### PR TITLE
devcontainer: use GHCR prebuilt image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
 {
   "name": "Odoo Devcontainer",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": ".."
-  },
+  "image": "ghcr.io/greencodeerp-bit/odoo-devcontainer-base:latest",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -16,6 +13,5 @@
       }
     }
   },
-  "postCreateCommand": "/home/codespace/.python/current/bin/python -m pip install --cache-dir /usr/local/share/pip-cache -r /workspaces/odoo/requirements.txt || true",
-  "remoteUser": "vscode"
+  "postCreateCommand": "/home/codespace/.python/current/bin/python -m pip install --cache-dir /usr/local/share/pip-cache -r /workspaces/odoo/requirements.txt || true"
 }


### PR DESCRIPTION
Switch devcontainer to use ghcr.io/greencodeerp-bit/odoo-devcontainer-base:latest as the base image to avoid local Docker builds and speed up container creation.