### PR TITLE
ci: group devcontainer changelog entries by date

### DIFF
--- a/.github/workflows/auto-pin-devcontainer-digest.yml
+++ b/.github/workflows/auto-pin-devcontainer-digest.yml
@@ -115,24 +115,42 @@ PY
             NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
             ENTRY="- $NOW  Digest: $DIGEST  Run: $RUN_URL  Commit: $commit_url\n"
 
-            # Create a branch, append the entry to doc/DEVCONTAINER_CHANGES.md and create a PR
-            BRANCH="devcontainer/chlog-${{ github.run_id }}"
+            # Create or reuse a date-based branch, append the entry to doc/DEVCONTAINER_CHANGES.md and create a PR
+            DATE=$(date -u +%Y-%m-%d)
+            BRANCH="devcontainer/chlog-$DATE"
             git config user.name "github-actions[bot]" || true
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com" || true
-            git checkout -b $BRANCH
+
+            # If the branch exists on the remote, fetch and check it out; otherwise create it
+            if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+              echo "Branch $BRANCH exists on origin - fetching and checking out"
+              git fetch origin "$BRANCH"
+              # Create local tracking branch if not present
+              if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+                git checkout "$BRANCH"
+                git pull --ff-only origin "$BRANCH" || true
+              else
+                git checkout -b "$BRANCH" --track origin/"$BRANCH"
+              fi
+            else
+              echo "Branch $BRANCH does not exist on origin - creating new branch"
+              git checkout -b "$BRANCH"
+            fi
+
             mkdir -p doc
             FILE=doc/DEVCONTAINER_CHANGES.md
             if [ ! -f "$FILE" ]; then
               echo "# Devcontainer changelog" > "$FILE"
               echo >> "$FILE"
             fi
-            echo "$ENTRY" >> "$FILE"
+            # Append entry
+            printf "%b" "$ENTRY" >> "$FILE"
             git add "$FILE"
             git commit -m "chore(devcontainer): add changelog entry for $DIGEST" || true
-            git push --set-upstream origin $BRANCH
+            git push --set-upstream origin "$BRANCH"
 
-            echo "Creating PR for changelog update"
-            gh pr create --repo ${{ github.repository }} --title "chore: devcontainer changelog $DIGEST" --body "Automated changelog entry: $DIGEST\nRun: $RUN_URL" --base 18.0 --head $BRANCH || true
+            echo "Creating PR for changelog update (or reusing existing)"
+            gh pr create --repo ${{ github.repository }} --title "chore: devcontainer changelog $DATE" --body "Automated changelog entry for $DATE:\nDigest: $DIGEST\nRun: $RUN_URL" --base 18.0 --head $BRANCH || true
             pr2=$(gh pr list --repo ${{ github.repository }} --head $BRANCH --json number --jq '.[0].number') || true
             if [ -n "$pr2" ] && [ "$pr2" != "null" ]; then
               gh pr merge $pr2 --repo ${{ github.repository }} --squash --admin || true


### PR DESCRIPTION
Workflow: use date-based changelog branch (devcontainer/chlog-YYYY-MM-DD) and reuse branch if already exists to group entries per day.