### PR TITLE
ci: support optional DEVCONTAINER_PAT for auth

### DIFF
--- a/.github/workflows/auto-pin-devcontainer-digest.yml
+++ b/.github/workflows/auto-pin-devcontainer-digest.yml
@@ -17,19 +17,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Determine auth token
+        id: auth
+        run: |
+          # Prefer a dedicated PAT in secrets.DEVCONTAINER_PAT, fallback to GITHUB_TOKEN
+          if [ -n "${{ secrets.DEVCONTAINER_PAT || '' }}" ]; then
+            echo "auth_token=${{ secrets.DEVCONTAINER_PAT }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "auth_token=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.auth.outputs.auth_token }}
 
       - name: Get digest for :latest
         id: get_digest
         run: |
           set -euo pipefail
           echo "Fetching manifest headers for latest..."
-          headers=$(curl -sI -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" "https://ghcr.io/v2/greencodeerp-bit/odoo-devcontainer-base/manifests/latest")
+          headers=$(curl -sI -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -u "${{ github.actor }}:${{ steps.auth.outputs.auth_token }}" "https://ghcr.io/v2/greencodeerp-bit/odoo-devcontainer-base/manifests/latest")
           echo "$headers"
           digest=$(echo "$headers" | tr -d '\r' | grep -i Docker-Content-Digest | awk '{print $2}')
           if [ -z "$digest" ]; then
@@ -67,7 +77,7 @@ PY
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.auth.outputs.auth_token }}
           commit-message: "ci(devcontainer): pin image to ${{ steps.get_digest.outputs.digest }}"
           branch: "devcontainer/auto-pin-${{ github.run_id }}"
           title: "ci: pin devcontainer image to ${{ steps.get_digest.outputs.digest }}"
@@ -78,7 +88,7 @@ PY
       - name: Auto-merge created PR
         if: always()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.auth.outputs.auth_token }}
           BRANCH: "devcontainer/auto-pin-${{ github.run_id }}"
         run: |
           set -euo pipefail

--- a/.github/workflows/auto-pin-devcontainer-digest.yml
+++ b/.github/workflows/auto-pin-devcontainer-digest.yml
@@ -115,24 +115,42 @@ PY
             NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
             ENTRY="- $NOW  Digest: $DIGEST  Run: $RUN_URL  Commit: $commit_url\n"
 
-            # Create a branch, append the entry to doc/DEVCONTAINER_CHANGES.md and create a PR
-            BRANCH="devcontainer/chlog-${{ github.run_id }}"
+            # Create or reuse a date-based branch, append the entry to doc/DEVCONTAINER_CHANGES.md and create a PR
+            DATE=$(date -u +%Y-%m-%d)
+            BRANCH="devcontainer/chlog-$DATE"
             git config user.name "github-actions[bot]" || true
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com" || true
-            git checkout -b $BRANCH
+
+            # If the branch exists on the remote, fetch and check it out; otherwise create it
+            if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+              echo "Branch $BRANCH exists on origin - fetching and checking out"
+              git fetch origin "$BRANCH"
+              # Create local tracking branch if not present
+              if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+                git checkout "$BRANCH"
+                git pull --ff-only origin "$BRANCH" || true
+              else
+                git checkout -b "$BRANCH" --track origin/"$BRANCH"
+              fi
+            else
+              echo "Branch $BRANCH does not exist on origin - creating new branch"
+              git checkout -b "$BRANCH"
+            fi
+
             mkdir -p doc
             FILE=doc/DEVCONTAINER_CHANGES.md
             if [ ! -f "$FILE" ]; then
               echo "# Devcontainer changelog" > "$FILE"
               echo >> "$FILE"
             fi
-            echo "$ENTRY" >> "$FILE"
+            # Append entry
+            printf "%b" "$ENTRY" >> "$FILE"
             git add "$FILE"
             git commit -m "chore(devcontainer): add changelog entry for $DIGEST" || true
-            git push --set-upstream origin $BRANCH
+            git push --set-upstream origin "$BRANCH"
 
-            echo "Creating PR for changelog update"
-            gh pr create --repo ${{ github.repository }} --title "chore: devcontainer changelog $DIGEST" --body "Automated changelog entry: $DIGEST\nRun: $RUN_URL" --base 18.0 --head $BRANCH || true
+            echo "Creating PR for changelog update (or reusing existing)"
+            gh pr create --repo ${{ github.repository }} --title "chore: devcontainer changelog $DATE" --body "Automated changelog entry for $DATE:\nDigest: $DIGEST\nRun: $RUN_URL" --base 18.0 --head $BRANCH || true
             pr2=$(gh pr list --repo ${{ github.repository }} --head $BRANCH --json number --jq '.[0].number') || true
             if [ -n "$pr2" ] && [ "$pr2" != "null" ]; then
               gh pr merge $pr2 --repo ${{ github.repository }} --squash --admin || true


### PR DESCRIPTION
Workflow will prefer secrets.DEVCONTAINER_PAT and fallback to GITHUB_TOKEN. Use this if GITHUB_TOKEN lacks push/merge permission.